### PR TITLE
Completed user permissions and redirects

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -33,7 +33,7 @@ class ChildrenController < ApplicationController
       render 'show.html.erb'
     else
       flash[:warning] = 'You must be logged in to use this feature.'
-      redirect_to '/'
+      redirect_to '/users/sign_in'
     end
   end
 

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -5,9 +5,15 @@ class FamiliesController < ApplicationController
 
     # Get parents (when model is ready)
 
-    # Get children 
-    @children = Child.where(user_id: current_user.id)
+    # Get children
+    if current_user 
+      @children = Child.where(user_id: current_user.id)
 
-    render 'index.html.erb'
+      render 'index.html.erb'
+    else
+      flash[:warning] = 'You must be logged in to view this page.'
+
+      redirect_to '/users/sign_in'
+    end
   end
 end

--- a/app/views/partials/_layout-header.html.erb
+++ b/app/views/partials/_layout-header.html.erb
@@ -77,7 +77,9 @@
                     <a href="#">Trisomy Store</a>
                   </li>
                   <li>
-                    <a href="/family-dashboard">Family Dashboard</a>
+                    <% if current_user %>
+                      <%= link_to('Family Dashboard', '/family-dashboard') %>
+                    <% end %>
                   </li>
                 </ul>
                 <!-- main-menu end -->


### PR DESCRIPTION
1.  As an end user I want to make sure that I need to be logged into a valid account to view child profiles.  If user is not signed in and tries to access child profile URL (bookmarked etc...) user is redirected sign in page.

2. As a user not signed in, I will not see a link to my family's dashboard page, and if I try to go to that page when signed in, I will be redirected to the sign-in page.