### PR TITLE
changed redirect after deleting participant to go back to family dash…

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -101,7 +101,7 @@ class ChildrenController < ApplicationController
   def destroy
     @child = Child.find_by(id: params[:id])
     @child.destroy
-    redirect_to '/'
+    redirect_to '/family-dashboard'
   end
 
   def register


### PR DESCRIPTION
- When deleting a participant from the Edit page I changed it to redirect the user back to the family dashboard and not to the index/homepage