### PR TITLE
fixed family trisomy_type error

### DIFF
--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -43,7 +43,6 @@ class FamiliesController < ApplicationController
       city: params["family"]["city"],
       state: params["family"]["state"],
       story: params["family"]["story"],
-      trisomy_type: params["family"]["trisomy_type"],
       user_id: current_user.id
       )
 


### PR DESCRIPTION
Creating a family no longer causes trisomy_type error.  Rspec runs smoothly now as well.